### PR TITLE
Prepare v0.5.0 and start a changelog

### DIFF
--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -1,0 +1,14 @@
+name: "Enforce changelog"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dangoslen/changelog-enforcer@v3
+        with:
+          changeLogPath: 'CHANGELOG.md'
+          skipLabels: 'skip-changelog'

--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -3,12 +3,17 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
+permissions:
+  contents: read
+
 jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dangoslen/changelog-enforcer@v3
+      # pinned to a commit rather than a tag, since a tag on a third party action
+      # can be moved to point at different code
+      - uses: dangoslen/changelog-enforcer@8b5e9dc3121363bb7c0115f8533404d92af382de # v3.7.0
         with:
           changeLogPath: 'CHANGELOG.md'
           skipLabels: 'skip-changelog'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+Notable changes to SolarPosition.jl are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses
+[semantic versioning](https://semver.org/).
+
+Releases before v0.5.0 predate this file. See the
+[GitHub releases](https://github.com/JuliaAstro/SolarPosition.jl/releases) for those.
+
+## unreleased
+
+### Added
+
+- `Michalsky` positioning algorithm, covering both the original and the standard Julian date
+  and with the Spencer azimuth correction available as an option
+  [#120](https://github.com/JuliaAstro/SolarPosition.jl/pull/120)
+- `Iqbal` positioning algorithm
+  [#118](https://github.com/JuliaAstro/SolarPosition.jl/pull/118)
+- `Interpolated`, which precomputes cubic B-splines of SPA's geocentric solar coordinates and
+  reconstructs positions analytically, roughly 10x faster per query at matching accuracy. One
+  interpolant serves every observer. Added alongside `solar_rate`
+  [#117](https://github.com/JuliaAstro/SolarPosition.jl/pull/117)
+- Type-generic precision. Every algorithm computes at the `Observer{T}` element type, with
+  `Float32`, `Float64`, `Float128` and `BigFloat` supported, and a converting
+  `Observer{T}(lat, lon, ...)` constructor
+  [#93](https://github.com/JuliaAstro/SolarPosition.jl/pull/93),
+  [#94](https://github.com/JuliaAstro/SolarPosition.jl/pull/94)
+- Solar positions are differentiable with ForwardDiff.jl, with no extension package needed,
+  including with respect to a refraction model's pressure and temperature
+  [#116](https://github.com/JuliaAstro/SolarPosition.jl/pull/116),
+  [#119](https://github.com/JuliaAstro/SolarPosition.jl/pull/119)
+- Uncertainty propagation with Measurements.jl works throughout, and correlations are
+  preserved, so quantities sharing an input stay consistent
+  [#122](https://github.com/JuliaAstro/SolarPosition.jl/pull/122)
+- `transit_sunrise_sunset_seconds`, returning the events as seconds since midnight UTC at the
+  observer's element type. `transit_sunrise_sunset` rounds to a whole second to build a
+  `DateTime`, which discards the sub-second part along with any uncertainty or derivative the
+  element type carries. This variant keeps all three
+  [#122](https://github.com/JuliaAstro/SolarPosition.jl/pull/122)
+
+### Changed
+
+- TimeZones.jl moved from a dependency to a package extension. `ZonedDateTime` input and
+  zoned sunrise and sunset still work, but only once TimeZones is loaded, which it must be in
+  order to construct a `ZonedDateTime` in the first place. Users who only pass a `DateTime`
+  no longer pay for TZJData and its download stack
+  [#121](https://github.com/JuliaAstro/SolarPosition.jl/pull/121)
+- Refraction model parameters promote against the observer's element type, so a model built
+  at a wider precision widens the result
+  [#119](https://github.com/JuliaAstro/SolarPosition.jl/pull/119)
+
+### Fixed
+
+- Inverse trigonometric arguments are clamped to their valid domain, so low-precision element
+  types no longer throw a `DomainError` on rounding
+  [#94](https://github.com/JuliaAstro/SolarPosition.jl/pull/94)
+- Algorithms take their time base through magnitude-safe day and century counts since J2000
+  rather than the full Julian Date, which made `Float32` unusable
+  [#93](https://github.com/JuliaAstro/SolarPosition.jl/pull/93),
+  [#94](https://github.com/JuliaAstro/SolarPosition.jl/pull/94)
+- The `Observer` inner constructor derives its zero defaults from an argument instead of the
+  element type, lifting the requirement that `zero` be defined on the bare type
+  [#122](https://github.com/JuliaAstro/SolarPosition.jl/pull/122)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases before v0.5.0 predate this file. See the
 
 ## unreleased
 
+## v0.5.0 - 2026-07-31
+
 ### Added
 
 - `Michalsky` positioning algorithm, covering both the original and the standard Julian date
@@ -61,3 +63,7 @@ Releases before v0.5.0 predate this file. See the
 - The `Observer` inner constructor derives its zero defaults from an argument instead of the
   element type, lifting the requirement that `zero` be defined on the bare type
   [#122](https://github.com/JuliaAstro/SolarPosition.jl/pull/122)
+- Corrected the `ARCHER` bibliography entry, which pointed at an unrelated 1980 conference
+  paper. The model comes from Archer's comment on Walraven's "Calculating the position of the
+  sun", now cited with its DOI
+  [#123](https://github.com/JuliaAstro/SolarPosition.jl/pull/123)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SolarPosition"
 uuid = "5b9d1343-a731-5a90-8730-7bf8d89bf3eb"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Stefan de Lange"]
 
 [workspace]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -41,6 +41,7 @@ makedocs(;
             "guides/getting-started.md",
             "guides/precision.md",
             "guides/autodiff.md",
+            "guides/uncertainty.md",
             "guides/plotting.md",
             "guides/parallel.md",
             "guides/interpolation.md",

--- a/docs/src/guides/autodiff.md
+++ b/docs/src/guides/autodiff.md
@@ -135,25 +135,10 @@ annual irradiance than the best fixed panel from the previous example.
 
 ## One day of tracker operation
 
-One day of operation makes the behaviour concrete. The site is the Van Gogh Museum in
-Amsterdam with the tracker axis aimed due south. Negative rotation faces the panel
-east. All curves run from 00:00 to 24:00, with the tracker holding its sunrise and
-sunset angles overnight. The upper panel compares the tracker rotation against the
-analytical rotation computed from first principles with only the solstice declination,
-the latitude, and the hour angle, ignoring the equation of time. The dashed curve lies
-exactly on the solid one until the ±60° limits cut it off, while the analytical ideal
-keeps following the sun below the horizon and wraps at ±180° late in the evening when
-the sun passes due north. The lower panel shows the sun elevation, negative at night,
-and the angle of incidence between the panel normal and the sun, for the tracker and
-for a fixed panel at 30° tilt facing south. The tracked angle of incidence touches
-zero exactly when the sun crosses due east and due west, because only then does the
-sun lie in the tracker's rotation plane, and its local maximum at noon equals the
-solar zenith angle because the panel is flat at that moment. The fixed panel aligns
-with the sun only once, near noon, where it beats the tracker: the horizontal axis
-cannot tilt the panel toward the south, so around midday the south facing fixed panel
-points closer to the sun. Recovering that noon deficit is why tilted single axis
-trackers exist. At night both angles of incidence exceed 90° since the sun is behind
-the panels:
+A full day makes the behaviour concrete: the Van Gogh Museum in Amsterdam, tracker axis
+aimed due south, negative rotation facing the panel east.
+
+Start with the sun's position at one minute resolution across the whole day.
 
 ```@example autodiff
 using CairoMakie
@@ -164,16 +149,24 @@ axis_south = 180.0
 day = collect(DateTime(2024, 6, 21):Minute(1):DateTime(2024, 6, 22))
 day_pos = solar_position(vgm, day, PSA(), NoRefraction())
 hours = [Dates.value(t - day[1]) / 3_600_000 for t in day]
+elevation = [p.elevation for p in day_pos]
+nothing # hide
+```
 
-# tracker rotation, held at its sunrise and sunset angles overnight
+The tracker rotation, clamped to ±60° and held at its sunrise and sunset angles overnight.
+
+```@example autodiff
 rot(p) = clamp(atand(tand(p.zenith) * sind(p.azimuth - axis_south)), -60.0, 60.0)
 sunup = [p.elevation > 0 for p in day_pos]
 first_up, last_up = findfirst(sunup), findlast(sunup)
 rotation = [rot(day_pos[clamp(i, first_up, last_up)]) for i in eachindex(day_pos)]
+nothing # hide
+```
 
-elevation = [p.elevation for p in day_pos]
+The angle between the sun and the panel normal, for the tracker and for a fixed reference
+panel at 30° tilt facing south.
 
-# angle of incidence against the actual panel orientation
+```@example autodiff
 function cos_aoi(p, R, axis_azimuth)
     panel_azimuth = axis_azimuth + (R < 0 ? -90 : 90)
     return cosd(p.zenith) * cosd(R) +
@@ -181,14 +174,17 @@ function cos_aoi(p, R, axis_azimuth)
 end
 aoi = [acosd(clamp(cos_aoi(p, R, axis_south), -1, 1)) for (p, R) in zip(day_pos, rotation)]
 
-# fixed reference panel at 30 degree tilt facing south
 aoi_fixed = [
     acosd(clamp(cosd(p.zenith) * cosd(30) + sind(p.zenith) * sind(30) * cosd(p.azimuth - 180), -1, 1))
         for p in day_pos
 ]
+nothing # hide
+```
 
-# analytical ideal rotation from declination, latitude, and hour angle alone,
-# with one NaN inserted at the 180 degree wrap
+The analytical ideal, from the solstice declination, latitude, and hour angle alone,
+ignoring the equation of time. A `NaN` marks where it wraps at ±180°.
+
+```@example autodiff
 decl = 23.437
 lat, lon = vgm.latitude, vgm.longitude
 omega = [15 * (h - 12) + lon for h in hours]
@@ -199,7 +195,12 @@ analytical = [
 for i in eachindex(analytical)[2:end]
     abs(analytical[i] - analytical[i - 1]) > 180 && (analytical[i - 1] = NaN)
 end
+nothing # hide
+```
 
+Finally the figure, rotation above and angles below.
+
+```@example autodiff
 # colorblind safe hues from the Wong palette, validated for each within panel group
 blue, orange, green, vermilion, skyblue = "#0072B2", "#E69F00", "#009E73", "#D55E00", "#56B4E9"
 
@@ -227,3 +228,11 @@ xlims!(ax2, 0, 24)
 axislegend(ax2; position = :ct)
 fig
 ```
+
+Three things to read from it. The tracker rotation lies exactly on the analytical curve
+until the ±60° limits cut it off, while the ideal keeps following the sun below the horizon
+and wraps when it passes due north. The tracked angle of incidence touches zero exactly when
+the sun crosses due east and due west, the only moments the sun lies in the tracker's
+rotation plane, and its local maximum at noon equals the solar zenith because the panel is
+flat then. The fixed panel beats the tracker around midday, since a horizontal axis cannot
+tilt the panel south; recovering that noon deficit is why tilted single axis trackers exist.

--- a/docs/src/guides/benchmarking.md
+++ b/docs/src/guides/benchmarking.md
@@ -80,7 +80,6 @@ times = collect(DateTime(2024, 1, 1):Hour(1):DateTime(2024, 12, 31, 23))
         ("NOAA", NOAA()),
         ("Walraven", Walraven()),
         ("USNO", USNO()),
-        ("Iqbal", Iqbal()),
     ]
 
     # Collect accuracy data
@@ -135,7 +134,7 @@ percentile) for each algorithm compared to SPA.
     )
 
     # Sort by algorithm order
-    algo_order = ["PSA", "NOAA", "Walraven", "USNO", "Iqbal"]
+    algo_order = ["PSA", "NOAA", "Walraven", "USNO"]
     algo_stats = algo_stats[sortperm([findfirst(==(algo), algo_order) for algo in algo_stats.Algorithm]), :]
     xs = 1:nrow(algo_stats)
 
@@ -289,7 +288,7 @@ sizes, from single timestamp calculations to bulk operations with 10,000 timesta
     )
 
     for (name, algo) in [("PSA", PSA()), ("NOAA", NOAA()), ("Walraven", Walraven()),
-                          ("USNO", USNO()), ("SPA", SPA()), ("Iqbal", Iqbal())]
+                          ("USNO", USNO()), ("SPA", SPA())]
         b = @benchmark solar_position($obs, $dt, $algo) samples=100 evals=10
         push!(single_benchmarks, (
             Algorithm = name,
@@ -322,7 +321,7 @@ sizes, from single timestamp calculations to bulk operations with 10,000 timesta
         times_vec = collect(DateTime(2024, 1, 1):Hour(1):(DateTime(2024, 1, 1) + Hour(n-1)))
 
         for (name, algo) in [("PSA", PSA()), ("NOAA", NOAA()), ("Walraven", Walraven()),
-                              ("USNO", USNO()), ("SPA", SPA()), ("Iqbal", Iqbal())]
+                              ("USNO", USNO()), ("SPA", SPA())]
             b = @benchmark solar_position($obs, $times_vec, $algo) samples=10 evals=1
             time_ms = median(b.times) / 1e6
             push!(vector_benchmarks, (
@@ -353,8 +352,8 @@ sizes, from single timestamp calculations to bulk operations with 10,000 timesta
         backgroundcolor = :transparent,
     )
 
-    colors = [:blue, :orange, :green, :purple, :red, :teal]
-    algo_names = ["PSA", "NOAA", "Walraven", "USNO", "SPA", "Iqbal"]
+    colors = [:blue, :orange, :green, :purple, :red]
+    algo_names = ["PSA", "NOAA", "Walraven", "USNO", "SPA"]
 
     for (i, algo) in enumerate(algo_names)
         data = filter(r -> r.Algorithm == algo, vector_benchmarks)
@@ -431,7 +430,6 @@ solposx_algorithms = Dict(
     "Walraven" => (sp.walraven, NamedTuple()),
     "USNO" => (sp.usno, NamedTuple()),
     "SPA" => (sp.spa, NamedTuple()),
-    "Iqbal" => (sp.iqbal, NamedTuple()),
 )
 
 lat, lon = 51.5074, -0.1278
@@ -461,7 +459,7 @@ We benchmark both libraries across different input sizes:
         py_times_idx = create_pandas_times(n)
 
         for (algo_name, algo) in [("PSA", PSA()), ("NOAA", NOAA()), ("Walraven", Walraven()),
-                                   ("USNO", USNO()), ("SPA", SPA()), ("Iqbal", Iqbal())]
+                                   ("USNO", USNO()), ("SPA", SPA())]
             # Julia benchmark
             julia_bench = @benchmark solar_position($obs, $julia_times_vec, $algo) samples=5 evals=1
             julia_time_ms = median(julia_bench.times) / 1e6
@@ -497,8 +495,8 @@ We benchmark both libraries across different input sizes:
     fig5 = Figure(size = (600, 750), backgroundcolor = :transparent, fontsize = 12, textcolor = "#f5ab35")
 
     # Group by algorithm for plotting
-    algo_names = ["PSA", "NOAA", "Walraven", "USNO", "SPA", "Iqbal"]
-    colors_julia = [:blue, :green, :purple, :orange, :red, :teal]
+    algo_names = ["PSA", "NOAA", "Walraven", "USNO", "SPA"]
+    colors_julia = [:blue, :green, :purple, :orange, :red]
 
     ax1 = Axis(fig5[1, 1],
         title = "Computation Time: Julia vs Python",
@@ -623,8 +621,7 @@ both Julia and Python implementations.
         "NOAA" => :orange,
         "Walraven" => :green,
         "USNO" => :purple,
-        "SPA" => :red,
-        "Iqbal" => :teal
+        "SPA" => :red
     )
 
     # Marker scheme for library

--- a/docs/src/guides/new-algorithm.md
+++ b/docs/src/guides/new-algorithm.md
@@ -75,22 +75,28 @@ Here's the basic structure:
 
 ```julia
 function _solar_position(obs::Observer{T}, dt::DateTime, alg::SimpleAlgorithm) where {T}
-    # 1. Convert datetime to Julian date
-    jd = datetime2julian(dt)
+    # 1. Take the time base at the observer's precision
+    n = julian_day_j2000(T, dt)    # days since J2000.0
+    hour = fractional_hour(T, dt)  # decimal hours
 
-    # 2. Calculate days since J2000.0 epoch
-    n = jd - 2451545.0
-
-    # 3. Compute solar coordinates (declination, hour angle, etc.)
+    # 2. Compute solar coordinates (declination, hour angle, etc.)
     # ... your algorithm's calculations here ...
 
-    # 4. Calculate local horizontal coordinates
-    # ... azimuth and elevation calculations ...
+    # 3. Calculate local horizontal coordinates, clamping the inverse trig argument
+    elevation = asind(unit_clamp(sin_δ * obs.sin_lat + cos_δ * obs.cos_lat * cos_ω))
+    # ... azimuth calculation ...
 
-    # 5. Return the result
+    # 4. Return the result
     return SolPos{T}(azimuth_deg, elevation_deg, zenith_deg)
 end
 ```
+
+!!! warning "Never call `datetime2julian` inside an algorithm"
+    A full Julian Date is around 2.45e6. Materializing that at `T` spends most of the
+    mantissa on the epoch offset and leaves `Float32` with no useful precision. Always go
+    through `julian_day_j2000`, `julian_century`, or `fractional_hour` from `timebase.jl`,
+    which count from J2000.0 and stay small. No algorithm in the package uses
+    `datetime2julian`.
 
 ### Key Implementation Notes
 
@@ -108,7 +114,7 @@ end
 3. **Type parameter `T`** ensures numerical precision is preserved from the `Observer`
 
 4. **Angle conventions**:
-   - Azimuth: 0° = North, positive clockwise, range [0°, 360°]
+   - Azimuth: 0° = North, positive clockwise, normalized to [0°, 360°)
    - Elevation: angle above horizon, range [-90°, 90°]
    - Zenith: 90° - elevation, range [0°, 180°]
 
@@ -138,8 +144,8 @@ If your algorithm should apply a specific refraction model by default:
 ```julia
 using ..Refraction: HUGHES, DefaultRefraction
 
-function _solar_position(obs, dt, alg::SimpleAlgorithm, ::DefaultRefraction)
-    return _solar_position(obs, dt, alg, HUGHES())
+function _solar_position(obs::Observer{T}, dt, alg::SimpleAlgorithm, ::DefaultRefraction) where {T}
+    return _solar_position(obs, dt, alg, HUGHES{T}())
 end
 
 # Return type for DefaultRefraction
@@ -149,6 +155,11 @@ result_type(::Type{SimpleAlgorithm}, ::Type{DefaultRefraction}, ::Type{T}) where
 
 The `result_type` function tells the system what return type to expect, enabling
 type-stable code for vectorized operations.
+
+!!! tip "Build the default model at `T`"
+    Write `HUGHES{T}()` rather than `HUGHES()`. The latter is `HUGHES{Float64}`, which
+    promotes the result back to `Float64` and quietly undoes a `Float32` or `BigFloat`
+    observer. See [`NOAA`](@ref SolarPosition.Positioning.NOAA) for the working pattern.
 
 ## [Step 4: Export the Algorithm](@id step-4-export)
 
@@ -166,28 +177,34 @@ include("simple.jl")  # Add your new file
 export SimpleAlgorithm
 ```
 
-### 4.2 Export from Main Module
+### 4.2 Nothing to Do in the Main Module
 
-Edit `src/SolarPosition.jl` to re-export your algorithm:
-
-```julia
-using .Positioning:
-    Observer, PSA, NOAA, Walraven, USNO, SPA, SimpleAlgorithm, solar_position, solar_position!
-
-# ... later in exports ...
-export PSA, NOAA, Walraven, USNO, SPA, SimpleAlgorithm
-```
+`src/SolarPosition.jl` pulls the submodules in with `@reexport using .Positioning`, so
+anything the `Positioning` module exports is available from `SolarPosition` automatically.
+Exporting from `src/Positioning/Positioning.jl` in step 4.1 is the only export you need.
 
 ## [Step 5: Write Tests](@id step-5-write-tests)
 
-Create a test file following the naming convention `test/test-simple.jl`.
+Create a test file following the naming convention `test/positioning/test-simple.jl`. Any
+file matching `test-*.jl` anywhere under `test/` is discovered automatically and wrapped in
+a `@testset` named after the file.
+
+Add your algorithm to `test_algorithms()` in `test/positioning/expected-values.jl` as well.
+That list is shared, so a single entry enrolls it in the type stability, precision,
+automatic differentiation, and uncertainty testsets without touching any of them.
 
 !!! warning "Generating Validation Data"
-    It is required to validate your algorithm against known reference values. You
-    can use a reference implementation of your algorithm (if available) or compare against
-    trusted solar position calculators. Store these reference values in your test file
-    and use `@test` statements to ensure your implementation matches them. See the
-    existing test files like `test/test-psa.jl` for examples of how to structure these tests.
+    Validate against known reference values, either from a reference implementation of your
+    algorithm or from a trusted solar position calculator. Store them in your test file and
+    compare with `@test`. See `test/positioning/test-psa.jl` for the structure.
+
+!!! tip "Put reference timestamps on the 84.375 s grid"
+    The existing reference tables are exact `Float64` output from the Python package
+    solposx, generated at instants whose offset from noon UTC is a multiple of 84.375 s. The
+    full Julian Date of such an instant is exactly representable in `Float64`, so the
+    references carry no time-base quantization artifact and the tests can compare at
+    `atol = 1e-10`, or `1e-8` for SPA. Use whole seconds only, because solposx's `usno()`
+    mishandles sub-second times, and paste full round-trip digits.
 
 ### Running Tests
 
@@ -210,7 +227,13 @@ Pkg.test()
 ### Add to Documentation Pages
 
 Update `docs/src/positioning.md` to include your algorithm in the algorithm reference
-section.
+section, and add a row to the algorithm tables in `docs/src/index.md` and `README.md`.
+
+### Record it in the Changelog
+
+Add an entry under `## unreleased` in `CHANGELOG.md`. A pull request that touches no
+changelog fails the `Enforce changelog` workflow unless it carries the `skip-changelog`
+label, and a new algorithm is exactly the kind of change the file exists to record.
 
 ### Add Literature References
 
@@ -281,11 +304,15 @@ Before submitting your algorithm for review, ensure you've completed the followi
 | `_solar_position`  | Function implemented with correct signature                                                 |
 | Default refraction | Handling defined for [`DefaultRefraction`](@ref SolarPosition.Refraction.DefaultRefraction) |
 | `result_type`      | Function defined for [`DefaultRefraction`](@ref SolarPosition.Refraction.DefaultRefraction) |
-| Export             | Algorithm exported from both modules                                                        |
+| Time base          | Uses `timebase.jl` helpers, never `datetime2julian`                                         |
+| Inverse trig       | `asin`/`acos` arguments guarded with `unit_clamp`                                           |
+| Export             | Algorithm exported from `Positioning`, which re-exports automatically                       |
+| Shared test list   | Added to `test_algorithms()` in `test/positioning/expected-values.jl`                       |
 | Tests              | Cover basic functionality, refraction, vectors, and edge cases                              |
 | Test coverage      | Ensure tests cover all new code paths                                                       |
 | Pre-commit         | Checks pass (recommended locally, required in CI)                                           |
-| Documentation      | Update algorithm lists in `positioning.md`, `README.md`, and `refraction.md`                |
+| Documentation      | Update algorithm lists in `positioning.md`, `index.md`, and `README.md`                     |
+| Changelog          | Entry added under `## unreleased` in `CHANGELOG.md`                                         |
 | Literature         | References added to `refs.bib` and cited in docstrings                                      |
 
 ## Additional Resources

--- a/docs/src/guides/uncertainty.md
+++ b/docs/src/guides/uncertainty.md
@@ -44,6 +44,82 @@ times = collect(DateTime(2023, 6, 21, 10):Hour(2):DateTime(2023, 6, 21, 14))
 solar_position(obs, times).elevation
 ```
 
+## How much does a coordinate error matter?
+
+A GPS fix carries its own uncertainty, so a natural question is how much of it reaches the
+computed angles. Converting a horizontal position uncertainty in metres into degrees of
+latitude and longitude answers it directly, and sweeping that uncertainty shows the whole
+picture at once.
+
+```@example uncertainty
+m_per_deg_lat = 111_320.0
+m_per_deg_lon = 111_320.0 * cosd(52.35888)
+
+sigma_m = 10 .^ range(-2, 3; length = 60)
+angles = [
+    solar_position(
+        Observer(52.35888 ± (s / m_per_deg_lat), 4.88185 ± (s / m_per_deg_lon)),
+        DateTime(2024, 6, 21, 12), SPA(), NoRefraction(),
+    ) for s in sigma_m
+]
+sigma_elev = [Measurements.uncertainty(p.elevation) for p in angles]
+sigma_azim = [Measurements.uncertainty(p.azimuth) for p in angles]
+nothing # hide
+```
+
+Plotted against the accuracy the algorithms themselves claim:
+
+```@example uncertainty
+using CairoMakie
+
+blue, orange = "#0072B2", "#E69F00"
+
+fig = Figure(size = (700, 460))
+ax = Axis(
+    fig[1, 1];
+    xscale = log10, yscale = log10,
+    xlabel = "horizontal position uncertainty (m)",
+    ylabel = "resulting angular uncertainty (°)",
+    title = "Coordinate uncertainty against algorithm accuracy",
+    xgridcolor = (:gray, 0.2), ygridcolor = (:gray, 0.2),
+)
+
+# a typical consumer GNSS fix, roughly 3 to 10 m
+vspan!(ax, 3, 10; color = (:gray, 0.12))
+text!(ax, 5.5, 2.0e-7; text = "consumer\nGNSS", align = (:center, :bottom),
+    color = :gray, fontsize = 11)
+
+hlines!(ax, [0.0003]; xmax = 0.9, color = (:gray, 0.7), linestyle = :dash)
+hlines!(ax, [0.0083]; xmax = 0.9, color = (:gray, 0.7), linestyle = :dash)
+text!(ax, 0.012, 0.0003; text = "SPA ±0.0003°", align = (:left, :bottom),
+    color = :gray, fontsize = 11)
+text!(ax, 0.012, 0.0083; text = "PSA ±0.0083°", align = (:left, :bottom),
+    color = :gray, fontsize = 11)
+
+lines!(ax, sigma_m, sigma_azim; color = orange, linewidth = 2, label = "azimuth")
+lines!(ax, sigma_m, sigma_elev; color = blue, linewidth = 2, label = "elevation")
+text!(ax, 1300, sigma_azim[end]; text = "azimuth", color = orange,
+    align = (:left, :center), fontsize = 12)
+text!(ax, 1300, sigma_elev[end]; text = "elevation", color = blue,
+    align = (:left, :center), fontsize = 12)
+
+xlims!(ax, 0.008, 5000)
+axislegend(ax; position = :rb, framevisible = false)
+fig
+```
+
+Propagation is linear to first order, so both curves are straight on log axes: about
+9.0e-6° of elevation and 2.8e-5° of azimuth per metre of position error. A consumer fix
+good to 5 m therefore costs 4.5e-5° in elevation and 1.4e-4° in azimuth.
+
+Azimuth is the more sensitive of the two, and it reaches SPA's stated ±0.0003° at about
+11 m of position error, where elevation needs 33 m. Against PSA's ±0.0083° the margins are
+300 m and 920 m.
+
+So for a PSA-class algorithm the coordinates are never the limiting factor. For SPA at the
+weaker end of a consumer fix the two are comparable, which is worth knowing before blaming
+a disagreement on the algorithm.
+
 ## Refraction parameters
 
 Pressure and temperature are measured quantities too, and refraction models accept them

--- a/docs/src/guides/uncertainty.md
+++ b/docs/src/guides/uncertainty.md
@@ -1,0 +1,84 @@
+# [Uncertainty Propagation](@id uncertainty-propagation)
+
+The [`Observer{T}`](@ref SolarPosition.Positioning.Observer) element type is only
+constrained to `Real`, so measurement values flow through every algorithm and solar
+positions work with
+[Measurements.jl](https://github.com/JuliaPhysics/Measurements.jl). No extension package
+is needed. See the [Automatic Differentiation](@ref automatic-differentiation) guide for
+the other thing that genericity buys, and the [Numeric Precision](@ref numeric-precision)
+guide for the supported number types themselves.
+
+Give the coordinates an uncertainty and it reaches every returned angle:
+
+```@example uncertainty
+using SolarPosition
+using Dates
+using Measurements
+
+obs = Observer(52.35888 ± 0.01, 4.88185 ± 0.01)  # Van Gogh Museum, Amsterdam
+
+pos = solar_position(obs, DateTime(2023, 6, 21, 12))
+```
+
+## Correlations
+
+Results that share an input stay consistent, because Measurements tracks the derivative
+chain rather than combining variances blindly. Zenith is derived from elevation, so their
+sum carries no uncertainty at all:
+
+```@example uncertainty
+pos.elevation + pos.zenith
+```
+
+Treating the two as independent would instead report about `± 0.014`. This holds through
+the [`Observer`](@ref SolarPosition.Positioning.Observer)'s precomputed latitude trig,
+which is the part most likely to lose the correlation.
+
+Everything else the package offers behaves the same way. `Measurement{Float32}` stays
+`Float32`, and the vectorized, in-place, and table interfaces all carry uncertainties
+through unchanged:
+
+```@example uncertainty
+times = collect(DateTime(2023, 6, 21, 10):Hour(2):DateTime(2023, 6, 21, 14))
+
+solar_position(obs, times).elevation
+```
+
+## Refraction parameters
+
+Pressure and temperature are measured quantities too, and refraction models accept them
+with uncertainties in the same way. Pairing an *exact* observer with an uncertain
+atmosphere isolates what the weather alone contributes:
+
+```@example uncertainty
+exact = Observer(52.35888, 4.88185)
+low = DateTime(2023, 12, 21, 8)  # a low winter sun, where refraction is largest
+
+solar_position(exact, low, PSA(), HUGHES(101325.0 ± 500.0, 12.0 ± 2.0))
+```
+
+The geometric angles come back exact, since they do not depend on the atmosphere, while
+the apparent ones carry the pressure and temperature uncertainty. Making the observer
+uncertain as well widens both, and the two contributions combine in the apparent angles.
+
+## Sunrise and sunset
+
+Event times are a special case, because a `DateTime` cannot carry an uncertainty.
+[`transit_sunrise_sunset`](@ref) rounds to a whole second, so it returns the nominal times
+however uncertain the observer is:
+
+```@example uncertainty
+transit_sunrise_sunset(Observer(52.35888 ± 5.0, 4.88185 ± 5.0), Date(2023, 6, 21)).sunrise
+```
+
+[`transit_sunrise_sunset_seconds`](@ref) keeps the observer's element type instead, giving
+seconds since midnight UTC:
+
+```@example uncertainty
+transit_sunrise_sunset_seconds(obs, Date(2023, 6, 21))
+```
+
+Rounding to a whole second also costs the sub-second part, so this variant is the more
+precise one even with ordinary numbers, and it is the one to use with ForwardDiff. The
+`next_`/`previous_` helpers return a `DateTime` and drop the uncertainty in the same way
+[`transit_sunrise_sunset`](@ref) does.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -136,8 +136,7 @@ example.
 
 The same genericity makes the algorithms work with
 [Measurements.jl](https://github.com/JuliaPhysics/Measurements.jl), again with no
-extension package needed. Give the coordinates an uncertainty and it reaches every
-returned angle:
+extension package needed:
 
 ```@example srt
 using Measurements
@@ -152,41 +151,9 @@ derived from elevation, and their sum therefore carries no uncertainty at all:
 pos.elevation + pos.zenith
 ```
 
-Treating the two as independent would instead report about `± 0.014`. Everything else the
-package offers behaves the same way: `Measurement{Float32}` stays `Float32`, and the
-vectorized, in-place, and table interfaces all carry uncertainties through unchanged.
-
-### Refraction parameters
-
-Pressure and temperature are measured quantities too, and refraction models accept them
-with uncertainties in the same way. Pairing an exact observer with an uncertain atmosphere
-isolates what the weather alone contributes:
-
-```@example srt
-low = DateTime(2023, 12, 21, 8)  # a low winter sun, where refraction is largest
-
-solar_position(obs, low, PSA(), HUGHES(101325.0 ± 500.0, 12.0 ± 2.0))
-```
-
-The geometric angles come back exact, since they do not depend on the atmosphere, while
-the apparent ones carry the pressure and temperature uncertainty. Making the observer
-uncertain as well widens both, and the two contributions combine in the apparent angles.
-
-### Sunrise and sunset
-
-Event times are a special case, because a `DateTime` cannot carry an uncertainty.
-[`transit_sunrise_sunset`](@ref) rounds to a whole second and so returns the nominal
-times. [`transit_sunrise_sunset_seconds`](@ref) keeps the observer's element type
-instead, giving seconds since midnight UTC:
-
-```@example srt
-transit_sunrise_sunset_seconds(Observer(52.35888 ± 0.01, 4.88185 ± 0.01), Date(2023, 6, 21))
-```
-
-Rounding to a whole second also costs the sub-second part, so this variant is the more
-precise one even with ordinary numbers, and it is the one to use with ForwardDiff. The
-`next_`/`previous_` helpers return a `DateTime` and drop the uncertainty in the same way
-[`transit_sunrise_sunset`](@ref) does.
+The [Uncertainty Propagation](@ref uncertainty-propagation) guide covers uncertain
+refraction parameters and the sunrise and sunset event times, which need
+[`transit_sunrise_sunset_seconds`](@ref) to keep their uncertainty.
 
 ## Numeric precision
 
@@ -205,7 +172,7 @@ Atmospheric refraction correction algorithms available in SolarPosition.jl.
 | Algorithm                                                          | Reference                                                                                        | Atmospheric Parameters | Status |
 | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | ---------------------- | ------ |
 | [`HUGHES`](@ref SolarPosition.Refraction.HUGHES)                   | [Hughes, 1985](https://pvpmc.sandia.gov/app/uploads/sites/243/2022/10/Engineering-Astronomy.pdf) | Pressure, Temperature  | ✅     |
-| [`ARCHER`](@ref SolarPosition.Refraction.ARCHER)                   | Archer et al., 1980                                                                              | None                   | ✅     |
+| [`ARCHER`](@ref SolarPosition.Refraction.ARCHER)                   | [Archer, 1980](https://doi.org/10.1016/0038-092X(80)90410-7)                                     | None                   | ✅     |
 | [`BENNETT`](@ref SolarPosition.Refraction.BENNETT)                 | [Bennett, 1982](https://doi.org/10.1017/S0373463300022037)                                       | Pressure, Temperature  | ✅     |
 | [`MICHALSKY`](@ref SolarPosition.Refraction.MICHALSKY)             | [Michalsky, 1988](https://doi.org/10.1016/0038-092X(88)90045-X)                                  | None                   | ✅     |
 | [`SG2`](@ref SolarPosition.Refraction.SG2)                         | [Blanc & Wald, 2012](https://doi.org/10.1016/j.solener.2012.07.018)                              | Pressure, Temperature  | ✅     |

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -85,11 +85,14 @@
 }
 
 @article{Arc80,
-  author = {Archer, C. B. and Brockett, W. E. and Oakes, C. A.},
-  title = {Collector Control System Simulation},
-  journal = {Solar Energy Technology Conference},
+  author = {Archer, C. B.},
+  title = {Comments on ``Calculating the position of the sun''},
+  journal = {Solar Energy},
+  volume = {25},
+  number = {1},
+  pages = {91},
   year = {1980},
-  note = {Conference paper}
+  doi = {10.1016/0038-092X(80)90410-7}
 }
 
 @article{Wal78,


### PR DESCRIPTION
Prepares the v0.5.0 release and starts keeping a changelog.

## Changelog

Adds `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format,
backfilled with the user-facing changes since v0.4.2. That came from the 18 substantive
merged pull requests in that range, with the dependabot and pre-commit commits filtered out:
Michalsky, Iqbal, `Interpolated` and `solar_rate`, type-generic precision, ForwardDiff
support, Measurements support, `transit_sunrise_sunset_seconds`, the TimeZones extension
move, and the `unit_clamp` and magnitude-safe time base fixes.

Releases before v0.5.0 predate the file and are left to the GitHub releases page rather than
reconstructed, which seemed like poor value for the archaeology involved.

Adds `.github/workflows/enforce-changelog.yml`, the
[DocumenterVitepress.jl](https://github.com/LuxDL/DocumenterVitepress.jl/blob/main/.github/workflows/enforce-changelog.yml)
workflow, so pull requests have to record their own entry. A pull request that genuinely
needs none can carry the `skip-changelog` label.

## Version

Bumps `Project.toml` to 0.5.0. A minor bump rather than a patch, since
`transit_sunrise_sunset_seconds` is new public API.

## Benchmarking guide

Drops Iqbal from the benchmarking guide: the accuracy, single call, vector, solposx
comparison, and Pareto sections, plus its entry in the solposx function map. The colour
vectors are trimmed in step with the algorithm name vectors they are indexed against, since a
mismatch there would be a `BoundsError` during the docs build rather than a cosmetic problem.
Iqbal is untouched in the positioning and precision guides.

## Note for the tag

The changelog entries sit under `## unreleased` rather than a `## v0.5.0` heading, so that
any further fixes for this release land in the same section and the date is not guessed. At
tag time that heading becomes `## v0.5.0 - <date>` with a fresh empty `## unreleased` above
it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
